### PR TITLE
Renamed local variable to avoid name clash with function randomPatients.

### DIFF
--- a/tests/testthat/helper-base.R
+++ b/tests/testthat/helper-base.R
@@ -49,7 +49,7 @@ complexPoaPatients <- data.frame(
   stringsAsFactors = FALSE
 )
 
-randomPatients <- data.frame(
+randomPatientsData <- data.frame(
   visitId = sample(seq(1, np), replace = TRUE, size=n),
   icd9 = randomShortIcd9,
   poa = as.factor(sample(x=c("Y", "N", "n", "n", "y", "X", "E", "", NA),
@@ -57,7 +57,7 @@ randomPatients <- data.frame(
 )
 
 # random patients with icd9 codes selected from ahrq data
-randomPatientsAhrqIcd9 <- randomPatients
+randomPatientsAhrqIcd9 <- randomPatientsData
 randomPatientsAhrqIcd9[["icd9"]] <- randomSampleAhrq
 
 testTwenty <- structure(


### PR DESCRIPTION
The icd9 tests use a local variable randomPatients, but the icd9 package defines a function of the same name. Calling the package function currently still works with testthat because of the R lookup mechanism that ignores non-functions of the same name when looking for a function, and because of how testthat creates R environments for the tests. But, with new versions of testthat, fixed to work with the byte-code compiler of R, the icd9 tests will stop working because of this name clash. Using a different name for the local variable as suggested in the patch will work now and in the future, and is perhaps clearer (this particular feature of the R lookup mechanism is not most intuitive).